### PR TITLE
Replace email with actual user email address

### DIFF
--- a/resources/views/otp.blade.php
+++ b/resources/views/otp.blade.php
@@ -53,8 +53,8 @@
                 Sign-in to {{ config('app.name') }}
                 <div class="mt-2 text-sm text-zinc-500 dark:text-white/70">
                     Enter the alpha numeric code sent to
-                    <span class="font-semibold">test@example.com</span>
-                    . The code is case insensitive and dashes will be added
+                    <span class="font-semibold">{{ $email ?? 'test@example.com' }}</span>.
+                    The code is case insensitive and dashes will be added
                     automatically.
                 </div>
             </div>


### PR DESCRIPTION
Just a simple quick change.
I have seen that there is the an placeholder email shown when prompted to enter the OT-Code.