### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,11 +11,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.3, 8.4]
-        laravel: [11.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:
+          - laravel: 10.*
+            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,12 +10,10 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*, 13.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.21",
+        "laravel/pint": "1.29",
         "nunomaduro/collision": "^7.10.0||^8.5.0",
         "larastan/larastan": "^2.9.13||^3.0",
         "orchestra/testbench": "^8.22.0||^9.10.0||^10.0||^11.0",

--- a/composer.json
+++ b/composer.json
@@ -18,20 +18,20 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "nunomaduro/collision": "^8.5.0||^7.10.0",
-        "larastan/larastan": "^2.9.13",
-        "orchestra/testbench": "^9.10.0||^8.22.0",
-        "pestphp/pest": "^2.36",
-        "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.4",
-        "phpstan/phpstan": "1.12.12",
-        "phpstan/extension-installer": "1.4.3",
-        "phpstan/phpstan-deprecation-rules": "1.2.1",
-        "phpstan/phpstan-phpunit": "1.4.1"
+        "nunomaduro/collision": "^7.10.0||^8.5.0",
+        "larastan/larastan": "^2.9.13||^3.0",
+        "orchestra/testbench": "^8.22.0||^9.10.0||^10.0||^11.0",
+        "pestphp/pest": "^2.36||^3.0||^4.0",
+        "pestphp/pest-plugin-arch": "^2.7||^3.0||^4.0",
+        "pestphp/pest-plugin-laravel": "^2.4||^3.0||^4.0",
+        "phpstan/phpstan": "^1.12.12||^2.0",
+        "phpstan/extension-installer": "^1.4.3",
+        "phpstan/phpstan-deprecation-rules": "^1.2.1||^2.0",
+        "phpstan/phpstan-phpunit": "^1.4.1||^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/otpz.php
+++ b/config/otpz.php
@@ -1,5 +1,9 @@
 <?php
 
+use App\Models\User;
+use BenBjurstrom\Otpz\Actions\GetUserFromEmail;
+use BenBjurstrom\Otpz\Mail\OtpzMail;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -31,7 +35,7 @@ return [
     */
 
     'models' => [
-        'authenticatable' => App\Models\User::class,
+        'authenticatable' => User::class,
     ],
 
     /*
@@ -45,7 +49,7 @@ return [
     |
     */
 
-    'mailable' => BenBjurstrom\Otpz\Mail\OtpzMail::class,
+    'mailable' => OtpzMail::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -72,5 +76,5 @@ return [
     |
     */
 
-    'user_resolver' => BenBjurstrom\Otpz\Actions\GetUserFromEmail::class,
+    'user_resolver' => GetUserFromEmail::class,
 ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15,3 +15,8 @@ parameters:
 			count: 1
 			path: src/Models/Otp.php
 
+		-
+			message: "#^Trait BenBjurstrom\\\\Otpz\\\\Models\\\\Concerns\\\\HasOtps is used zero times and is not analysed\\.$#"
+			count: 1
+			path: src/Models/Concerns/HasOtps.php
+

--- a/src/Mail/OtpzMail.php
+++ b/src/Mail/OtpzMail.php
@@ -5,6 +5,7 @@ namespace BenBjurstrom\Otpz\Mail;
 use BenBjurstrom\Otpz\Models\Otp;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
@@ -28,7 +29,7 @@ class OtpzMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: __('otpz::otp.mail.otpz.subject') . config('app.name'),
+            subject: __('otpz::otp.mail.otpz.subject').config('app.name'),
         );
     }
 
@@ -56,7 +57,7 @@ class OtpzMail extends Mailable
     /**
      * Get the attachments for the message.
      *
-     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     * @return array<int, Attachment>
      */
     public function attachments(): array
     {

--- a/src/Models/Otp.php
+++ b/src/Models/Otp.php
@@ -40,7 +40,7 @@ class Otp extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $fillable = [
         'remember',

--- a/stubs/react/OtpzController.php
+++ b/stubs/react/OtpzController.php
@@ -127,7 +127,7 @@ class OtpzController extends Controller
     /**
      * Ensure the login request is not rate limited.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     protected function ensureIsNotRateLimited(Request $request): void
     {

--- a/stubs/vue/OtpzController.php
+++ b/stubs/vue/OtpzController.php
@@ -127,7 +127,7 @@ class OtpzController extends Controller
     /**
      * Ensure the login request is not rate limited.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     protected function ensureIsNotRateLimited(Request $request): void
     {

--- a/tests/Actions/AttemptOtpTest.php
+++ b/tests/Actions/AttemptOtpTest.php
@@ -5,6 +5,7 @@ use BenBjurstrom\Otpz\Enums\OtpStatus;
 use BenBjurstrom\Otpz\Exceptions\OtpAttemptException;
 use BenBjurstrom\Otpz\Models\Otp;
 use BenBjurstrom\Otpz\Tests\Support\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
@@ -99,7 +100,7 @@ it('throws exception for invalid code', function () {
 
 it('throws exception for non-existent otp', function () {
     expect(fn () => (new AttemptOtp)->handle(999, 'INVALIDCODE', 'test-session-id'))
-        ->toThrow(Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        ->toThrow(ModelNotFoundException::class);
 });
 
 it('allows attempt within 5 minute window', function () {


### PR DESCRIPTION
## Summary
- Add Laravel 13 to `illuminate/contracts` support range (`^10.0||^11.0||^12.0||^13.0`)
- Widen dev dependencies to resolve against Laravel 13: Testbench 11, Pest 4, PHPStan 2, Larastan 3
- Expand CI test matrix from L11-only to L10–L13, each on PHP 8.3 and 8.4 (8 jobs)
- Fix `$fillable` PHPDoc type (`list<string>`) for PHPStan 2 covariance check
- Baseline `HasOtps` trait-unused warning (consumer-facing trait, not used within `src/`)